### PR TITLE
Feature/ws reconnect

### DIFF
--- a/examples/websocket/reconnect/websocket_reconnect.go
+++ b/examples/websocket/reconnect/websocket_reconnect.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/samotarnik/bitstamp-go"
+)
+
+// Following app is an example of handling reconnect request from Websocket server. Note, that
+// this shows the semantics but
+type App struct {
+	client           *bitstamp.WsClient
+	requestNewClient chan struct{}
+	close            chan struct{}
+}
+
+// A very simple example of handling reconnect event. Every reconnect event is handled in such a way, that can
+// ensure no data loss.
+func NewApp() App {
+	c, err := bitstamp.NewWsClient()
+	if err != nil {
+		log.Panicf("error initializing client %v", err)
+	}
+	return App{
+		client:           c,
+		requestNewClient: make(chan struct{}),
+		close:            make(chan struct{}),
+	}
+}
+
+func (a *App) Run() {
+	a.client.Subscribe("live_orders_btcusd", "live_trades_btcusd")
+	for {
+		select {
+		case ev := <-a.client.Stream:
+			fmt.Printf("%#v\n", ev)
+			if a.client.IsReconnectRequest(ev) {
+				a.requestNewClient <- struct{}{}
+			}
+
+		case err := <-a.client.Errors:
+			fmt.Printf("--- ERROR: %#v\n", err)
+		case <-a.close:
+			// Wait before killing the app, as new connection must first be established
+			time.Sleep(2 * time.Second)
+			return
+		}
+	}
+}
+
+func main() {
+	for {
+		app := NewApp()
+		go app.Run()
+		<-app.requestNewClient
+		app.close <- struct{}{}
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -104,6 +104,14 @@ func (c *WsClient) Unsubscribe(channels ...string) {
 	}
 }
 
+// Determines whether server is requesting reconnect. If such a request is made by the server,
+// we should immediately reconnect.
+// Note: Bitstamp ensures, that once such a request is received by the client, any new websocket client is connected
+// to a healthy server.
+func (c *WsClient) IsReconnectRequest(event *WsEvent) bool {
+	return event.Event == "bts:request_reconnect"
+}
+
 func (c *WsClient) sendEvent(sub WsEvent) {
 	c.sendLock.Lock()
 	defer c.sendLock.Unlock()


### PR DESCRIPTION
Introduces a simple method that checks whether an event is actually a reconnect request. I didn't want to add internal "under the hood" logic for this behaviour, as I believe such a library should give users power to find out when such events happen via API, but leave them with liberty to handle events themselves however they like.

I also provided a very simple example of usage of such method. Example shows how not to lose any messages when such a request is made. Regardless, this is just a very simple example, as implementation really depends on the need of a user.

Made some local testing, and it works.